### PR TITLE
Added support for kGravatarDefaultImageType (404, mm, identicon, monster...

### DIFF
--- a/NSURL+Gravatar.h
+++ b/NSURL+Gravatar.h
@@ -8,8 +8,70 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ *  @brief Default image type for gravatar, a fallback in case the email was not found
+ */
+typedef NS_ENUM(NSUInteger, kGravatarDefaultImageType) {
+    
+    /**
+     *  @brief  Do not load any image if none is associated with the email hash,
+     *          instead return an HTTP 404 (File Not Found) response
+     */
+    kGravatarDefaultImageType404,
+    
+    /**
+     *  @brief  (mystery-man) a simple, cartoon-style silhouetted outline of
+     *          a person (does not vary by email hash)
+     */
+    kGravatarDefaultImageTypeMysteryMan,
+    
+    /**
+     *  @brief a geometric pattern based on an email hash
+     */
+    kGravatarDefaultImageTypeIdenticon,
+    
+    /**
+     *  @brief a generated 'monster' with different colors, faces, etc
+     */
+    kGravatarDefaultImageTypeMonsterId,
+    
+    /**
+     *  @brief generated faces with differing features and backgrounds
+     */
+    kGravatarDefaultImageTypeWavatar,
+    
+    /**
+     *  @brief awesome generated, 8-bit arcade-style pixelated faces
+     */
+    kGravatarDefaultImageTypeRetro,
+    
+    /**
+     *  @brief a transparent PNG image
+     */
+    kGravatarDefaultImageTypeBlank,
+};
+
 @interface NSURL (Gravatar)
 
-+(NSURL *)URLWithGravatarEmail:(NSString *)email size:(int)size;
+/**
+ *  @brief Builds a new URL for the desired gravatar
+ *
+ *  @param email the email address for gravatar
+ *  @param size  the desired size
+ *
+ *  @return built URL of the gravatar
+ */
++ (NSURL *)URLWithGravatarEmail:(NSString *)email size:(NSUInteger)size;
+
+/**
+ *  @brief Builds a new URL for the desired gravatar setting its default image type
+ *
+ *  @param email the email address for gravatar
+ *  @param size  the desired size
+ *  @param defaultImageType  desired default image type (kGravatarDefaultImageType)
+ *
+ *  @return built URL of the gravatar with desired size and default image
+ */
++  (NSURL *)URLWithGravatarEmail:(NSString *)email size:(NSUInteger)size defaultImageType:(kGravatarDefaultImageType)defaultImageType;
 
 @end

--- a/NSURL+Gravatar.m
+++ b/NSURL+Gravatar.m
@@ -11,15 +11,91 @@
 
 @implementation NSURL (Gravatar)
 
-+(NSURL *)URLWithGravatarEmail:(NSString *)email size:(int)size
-{
+NSString * const kGravatar404DefaultImageStringValue        = @"404";
+NSString * const kGravatarMysteryManDefaultImageStringValue = @"mysteryman";
+NSString * const kGravatarIdenticonDefaultImageStringValue  = @"identicon";
+NSString * const kGravatarMonsterIdDefaultImageStringValue  = @"monsterid";
+NSString * const kGravatarWavatarDefaultImageStringValue    = @"wavatar";
+NSString * const kGravatarRetroDefaultImageStringValue      = @"retro";
+NSString * const kGravatarBlankDefaultImageStringValue      = @"blank";
+
+#pragma mark - Public
+
++ (NSURL *)URLWithGravatarEmail:(NSString *)email size:(NSUInteger)size {
+    
+    return [[self class] URLWithGravatarEmail:email
+                                         size:size
+                             defaultImageType:kGravatarDefaultImageType404];
+}
+
++ (NSURL *)URLWithGravatarEmail:(NSString *)email size:(NSUInteger)size defaultImageType:(kGravatarDefaultImageType)defaultImageType {
+    
     NSString *hashedEmail = [self MD5: [email lowercaseString]];
-    NSString *gravatarURLString = [NSString stringWithFormat:@"http://www.gravatar.com/avatar/%@?d=404&size=%d", hashedEmail, size];
+    NSString *gravatarURLString = [NSString stringWithFormat:@"http://www.gravatar.com/avatar/%@?d=%@&size=%d",
+                                   hashedEmail,
+                                   NSStringFromGravatarImageType(defaultImageType),
+                                   size];
     return [NSURL URLWithString:gravatarURLString];
 }
 
-+ (NSString*)MD5:(NSString *)string
-{
+#pragma mark - Private 
+
+/**
+ *  @brief  Direct convertion from image type to its Gravatar internal
+ representation of default image types
+ *
+ *  @param type the type of Default image
+ *
+ *  @return a string representing with the internal format required for
+ *          building the URL with a valid default image type
+ */
+static NSString * NSStringFromGravatarImageType(kGravatarDefaultImageType type) {
+    
+    switch (type) {
+            
+        case kGravatarDefaultImageType404:
+            
+            return kGravatar404DefaultImageStringValue;
+            
+        case kGravatarDefaultImageTypeMysteryMan:
+            
+            return kGravatarMysteryManDefaultImageStringValue;
+            
+        case kGravatarDefaultImageTypeIdenticon:
+            
+            return kGravatarIdenticonDefaultImageStringValue;
+            
+        case kGravatarDefaultImageTypeMonsterId:
+            
+            return kGravatarMonsterIdDefaultImageStringValue;
+            
+        case kGravatarDefaultImageTypeWavatar:
+            
+            return kGravatarWavatarDefaultImageStringValue;
+            
+        case kGravatarDefaultImageTypeRetro:
+            
+            return kGravatarRetroDefaultImageStringValue;
+            
+        case kGravatarDefaultImageTypeBlank:
+            
+            return kGravatarBlankDefaultImageStringValue;
+            
+        default:
+            
+            return kGravatarDefaultImageType404;
+    }
+}
+
+/**
+ *  @brief MD5 Helper generator
+ *
+ *  @param string the string to transform
+ *
+ *  @return an MD5 representation of the provided string
+ */
++ (NSString*)MD5:(NSString *)string {
+    
     const char *pointer = [string UTF8String];
     unsigned char md5Buffer[CC_MD5_DIGEST_LENGTH];
     CC_MD5(pointer, strlen(pointer), md5Buffer);


### PR DESCRIPTION
Added a new helper method to convert from enum to string: `NSStringFromGravatarImageType(kGravatarDefaultImageType type)`

This will add default image support to your category like this:

`[NSURL URLWithGravatarEmail:userEmail size:40 defaultImageType:kGravatarDefaultImageTypeMonsterId]`
