### PR TITLE
Fixed warning caused by use of strlen as argument taking CC_LONG

### DIFF
--- a/NSURL+Gravatar.m
+++ b/NSURL+Gravatar.m
@@ -14,7 +14,7 @@
 
 @implementation NSURL (Gravatar)
 
-+(NSURL *)URLWithGravatarEmail:(NSString *)email size:(int)size
++ (NSURL *)URLWithGravatarEmail:(NSString *)email size:(int)size
 {
     NSString *hashedEmail = [self MD5:[email lowercaseString]];
     NSString *gravatarURLString = [NSString stringWithFormat:@"http://www.gravatar.com/avatar/%@?d=404&size=%d", hashedEmail, size];

--- a/NSURL+Gravatar.m
+++ b/NSURL+Gravatar.m
@@ -13,22 +13,21 @@
 
 +(NSURL *)URLWithGravatarEmail:(NSString *)email size:(int)size
 {
-    NSString *hashedEmail = [self MD5: [email lowercaseString]];
+    NSString *hashedEmail = [self MD5:[email lowercaseString]];
     NSString *gravatarURLString = [NSString stringWithFormat:@"http://www.gravatar.com/avatar/%@?d=404&size=%d", hashedEmail, size];
     return [NSURL URLWithString:gravatarURLString];
 }
 
-+ (NSString*)MD5:(NSString *)string
++ (NSString *)MD5:(NSString *)string
 {
     const char *pointer = [string UTF8String];
     unsigned char md5Buffer[CC_MD5_DIGEST_LENGTH];
-    CC_MD5(pointer, strlen(pointer), md5Buffer);
+    CC_MD5(pointer, (CC_LONG)[string lengthOfBytesUsingEncoding:NSUTF8StringEncoding], md5Buffer);
     NSMutableString *output = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
     for(int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
-        [output appendFormat:@"%02x",md5Buffer[i]];
+        [output appendFormat:@"%02x", md5Buffer[i]];
     }
     
-    return output;
+    return [output copy];
 }
-
 @end

--- a/NSURL+Gravatar.m
+++ b/NSURL+Gravatar.m
@@ -13,22 +13,22 @@
 
 +(NSURL *)URLWithGravatarEmail:(NSString *)email size:(int)size
 {
-    NSString *hashedEmail = [self MD5: [email lowercaseString]];
+    NSString *hashedEmail = [self MD5:[email lowercaseString]];
     NSString *gravatarURLString = [NSString stringWithFormat:@"http://www.gravatar.com/avatar/%@?d=404&size=%d", hashedEmail, size];
     return [NSURL URLWithString:gravatarURLString];
 }
 
-+ (NSString*)MD5:(NSString *)string
++ (NSString *)MD5:(NSString *)string
 {
     const char *pointer = [string UTF8String];
     unsigned char md5Buffer[CC_MD5_DIGEST_LENGTH];
-    CC_MD5(pointer, strlen(pointer), md5Buffer);
+    CC_MD5(pointer, (CC_LONG)[string lengthOfBytesUsingEncoding:NSUTF8StringEncoding], md5Buffer);
     NSMutableString *output = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
     for(int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
-        [output appendFormat:@"%02x",md5Buffer[i]];
+        [output appendFormat:@"%02x", md5Buffer[i]];
     }
     
-    return output;
+    return [output copy];
 }
 
 @end

--- a/NSURL+Gravatar.m
+++ b/NSURL+Gravatar.m
@@ -6,8 +6,11 @@
 //  Copyright (c) 2014 Bart van Zon. All rights reserved.
 //
 
+@import CommonCrypto;
+
 #import "NSURL+Gravatar.h"
-#import <CommonCrypto/CommonDigest.h>
+
+
 
 @implementation NSURL (Gravatar)
 
@@ -20,15 +23,17 @@
 
 + (NSString *)MD5:(NSString *)string
 {
-    const char *pointer = [string UTF8String];
-    unsigned char md5Buffer[CC_MD5_DIGEST_LENGTH];
-    CC_MD5(pointer, (CC_LONG)[string lengthOfBytesUsingEncoding:NSUTF8StringEncoding], md5Buffer);
-    NSMutableString *output = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
+    const char *stringPointer = [string UTF8String];
+    CC_LONG stringLength = (CC_LONG)[string lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+
+    unsigned char MD5ByteBuffer[CC_MD5_DIGEST_LENGTH];
+    CC_MD5(stringPointer, stringLength, MD5ByteBuffer);
+    NSMutableString *MD5StringOutput = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH];
     for(int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
-        [output appendFormat:@"%02x", md5Buffer[i]];
+        [MD5StringOutput appendFormat:@"%02x", MD5ByteBuffer[i]];
     }
     
-    return [output copy];
+    return [MD5StringOutput copy];
 }
 
 @end


### PR DESCRIPTION
In general you could just cast the value, but you might look over the substantive changes here and pick out what suits you. I would just like you to cast that strlen to CC_LONG if nothing else so Xcode doesn't display a warning.
